### PR TITLE
Fix build error when current code page is special

### DIFF
--- a/miniMax/miniMax.cpp
+++ b/miniMax/miniMax.cpp
@@ -127,7 +127,7 @@ void *miniMax::getBestChoice(unsigned int tilLevel, unsigned int *choice, unsign
 // Name: calculateDatabase()
 // Desc: Calculates the database, which must be already open.
 //-----------------------------------------------------------------------------
-void miniMax::calculateDatabase(unsigned int maxDepthOfTree, bool onlyPrepareLayer, unsigned int compressionAlgId)
+void miniMax::calculateDatabase(unsigned int maxDepthOfTree, bool onlyPrepareLayer)
 {
    	// locals
 	bool			abortCalculation = false;

--- a/miniMax/miniMax.h
+++ b/miniMax/miniMax.h
@@ -260,7 +260,7 @@ public:
 
 	// Database functions
 	bool					openDatabase					(const char *directory, unsigned int maximumNumberOfBranches);
-	void					calculateDatabase           	(unsigned int maxDepthOfTree, bool onlyPrepareLayer, unsigned int compressionAlgId);
+	void					calculateDatabase           	(unsigned int maxDepthOfTree, bool onlyPrepareLayer);
 	bool					isCurrentStateInDatabase		(unsigned int threadNo);
 	void					closeDatabase					();
     void                    unloadAllLayers             	();

--- a/miniMax/miniMaxWinCalcDb.cpp
+++ b/miniMax/miniMaxWinCalcDb.cpp
@@ -458,7 +458,7 @@ void miniMaxWinCalcDb::threadSolve()
 	
 	// calculate
 	pMiniMax->setOutputStream(outputStream, nullptr, nullptr);
-	pMiniMax->calculateDatabase(maxDepthOfTree, onlyPrepareLayer, 0);
+	pMiniMax->calculateDatabase(maxDepthOfTree, onlyPrepareLayer);
 
 	// turn "running" LED off
 	hLabelCalculationRunning	.setText(L"Calculation stopped");

--- a/wildWeasel/wwGuiElement.cpp
+++ b/wildWeasel/wwGuiElement.cpp
@@ -147,7 +147,7 @@ void wildWeasel::guiElement::setText(const WCHAR* newText)
 	text.assign(newText);
 
 	// ... work-around for chars, which does not exist in the font file. should be solved differently
-	replace(text.begin(), text.end(), 8217,  39);	// '’' -> "'"	
+	replace(text.begin(), text.end(), 8217,  39);	// ''' -> "'"	
 	replace(text.begin(), text.end(), '\t', ' ');
 };
 

--- a/wildWeasel/wwRotCtrlCube.cpp
+++ b/wildWeasel/wwRotCtrlCube.cpp
@@ -524,7 +524,7 @@ void wildWeasel::rotationControlCube::rotate(faceAreaIndex newFaceAreaState, uns
 	faceAreaState	= newFaceAreaState;
 	rollState		= newRollState;
 
-	// the 90° buttons shall only be visible when the center area is shown
+	// the 90 degree buttons shall only be visible when the center area is shown
 	guiElemState newState = (faceAreaState.area == idCenterArea ? guiElemState::DRAWED : guiElemState::HIDDEN);
 	buttonLeft		.setState(newState);
 	buttonTop		.setState(newState);

--- a/wildWeasel/wwRotCtrlCube.h
+++ b/wildWeasel/wwRotCtrlCube.h
@@ -70,14 +70,14 @@ private:
 
 	plainButton							buttonRollLeft;															// cycles through the 4 rollStates
 	plainButton							buttonRollRight;														// ''
-	plainButton							buttonLeft;																// rotates the cube by 90°
+	plainButton							buttonLeft;																// rotates the cube by 90 degree
 	plainButton							buttonTop;																// ''
 	plainButton							buttonRight;															// ''
 	plainButton							buttonBottom;															// ''
 	plainButton							buttonHome;																// rotates the cube back, so that the front area is the current one
 	areaClass							areas[numFaces][numAreas];												// arrays with all areas
 	faceAreaIndex						faceAreaState;															// orientation state - current area belonging to the orientation state of the cube
-	faceAreaRollIndex					stateAfter90DegRot[numFaces][maxRollStates][idNum90DegRotations];		// target state after a 90° rotation, when a button buttonLeft, buttonRight, etc. was clicked
+	faceAreaRollIndex					stateAfter90DegRot[numFaces][maxRollStates][idNum90DegRotations];		// target state after a 90 degree rotation, when a button buttonLeft, buttonRight, etc. was clicked
 	unsigned int						numRollStates[numAreas];												// number of rollstates of each area (center=4, edge=2, corner=3)
 	unsigned int						rollState							= 0;								// orientation state - the object is rolled stepwise by 90/120/180 deg around the view axis n-times
 	color								colorNormalCenter					= color::gray;						// for inner center areas


### PR DESCRIPTION
Fix build failure in the Chinese environment

Error	C2065	'buttonTop': undeclared identifier
  MuehleWin	muehle\weasellibrary\wildweasel\wwrotctrlcube.cpp

Warning	C4819	The file contains a character that cannot be
  represented in the current code page.
Save the file in Unicode format to prevent data loss
  MuehleWin	muehle\weasellibrary\wildweasel\wwrotctrlcube.h	1